### PR TITLE
Add missing PWA icons

### DIFF
--- a/assets/icons/.gitkeep
+++ b/assets/icons/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to keep icons directory tracked.


### PR DESCRIPTION
## Summary
- remove the generated icon binaries from version control
- add a placeholder file so the `assets/icons` directory exists for user-provided icons

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3a45db528832f96ce7be1467a7c15