### PR TITLE
Add deity rarity with rainbow styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,10 +53,11 @@
       <div class="rarity-legend">
         <h2>Rarity Legend</h2>
         <ul>
-          <li class="rarity common">Common <span>60%</span></li>
+          <li class="rarity common">Common <span>59%</span></li>
           <li class="rarity rare">Rare <span>25%</span></li>
           <li class="rarity epic">Epic <span>12%</span></li>
           <li class="rarity legendary">Legendary <span>3%</span></li>
+          <li class="rarity deity">Deity <span>1%</span></li>
         </ul>
       </div>
       <div class="collection" aria-live="polite">

--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@ const rarities = {
   common: {
     key: 'common',
     label: 'Common',
-    weight: 60,
+    weight: 59,
     color: '#77d1f7'
   },
   rare: {
@@ -23,6 +23,12 @@ const rarities = {
     label: 'Legendary',
     weight: 3,
     color: '#f6c350'
+  },
+  deity: {
+    key: 'deity',
+    label: 'Deity',
+    weight: 1,
+    color: '#f3c8ff'
   }
 };
 
@@ -179,6 +185,25 @@ const catPool = [
       patternColor: 'linear-gradient(135deg, rgba(255,221,148,0.55), rgba(246,195,80,0.7))',
       patternOpacity: 0.34
     }
+  },
+  {
+    id: 'aurora-muse',
+    name: 'Aurora Muse',
+    rarity: 'deity',
+    weight: 1,
+    description: 'A cosmic storyteller whose tail paints shimmering auroras across the arcade ceiling.',
+    traits: {
+      'Favorite Treat': 'Sunrise sorbet',
+      Mood: 'Transcendent'
+    },
+    colors: {
+      base: '#fef2ff',
+      secondary: '#f6c8ff',
+      innerEar: '#ffe4ff',
+      accent: '#ffffff',
+      patternColor: 'linear-gradient(140deg, rgba(255,200,237,0.6), rgba(160,220,255,0.6), rgba(255,246,189,0.65))',
+      patternOpacity: 0.4
+    }
   }
 ];
 
@@ -208,7 +233,7 @@ const CRANE_MAX_CABLE = 360;
 const BALL_TOUCH_CLEARANCE = 4;
 const PLATFORM_TOUCH_OFFSET = 26;
 const BALL_COUNT = 12;
-const RARITY_SEQUENCE = ['common', 'rare', 'epic', 'legendary'];
+const RARITY_SEQUENCE = ['common', 'rare', 'epic', 'legendary', 'deity'];
 
 // -------------------- Weighted Distribution Helpers --------------------
 function buildDistribution(items, weightAccessor) {

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,16 @@
   --rare: #9c8cff;
   --epic: #ff8ad6;
   --legendary: #f6c350;
+  --deity: #f3c8ff;
+  --deity-border: conic-gradient(
+    from 45deg,
+    #ff8ad6,
+    #f6c350,
+    #77d1f7,
+    #9c8cff,
+    #7ef7b2,
+    #ff8ad6
+  );
 }
 
 * {
@@ -419,6 +429,12 @@ body {
   border: 2px solid rgba(246, 195, 80, 0.55);
 }
 
+.rarity.deity {
+  border: 2px solid transparent;
+  background: linear-gradient(0deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.9)) padding-box,
+    var(--deity-border) border-box;
+}
+
 .collection-hint {
   margin: 0 0 0.5rem;
   color: var(--muted);
@@ -487,6 +503,12 @@ body {
 .collection-list li .rarity-tag.rare { background: var(--rare); }
 .collection-list li .rarity-tag.epic { background: var(--epic); }
 .collection-list li .rarity-tag.legendary { background: linear-gradient(135deg, #f1ba36, #ffd972); color: #5f3d00; }
+.collection-list li .rarity-tag.deity {
+  color: #371b63;
+  border: 2px solid transparent;
+  background: linear-gradient(0deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.88)) padding-box,
+    var(--deity-border) border-box;
+}
 
 .result-panel {
   position: fixed;
@@ -544,6 +566,12 @@ body {
 .cat-card-inner.rarity-rare { box-shadow: 0 20px 45px rgba(156, 140, 255, 0.3); border-color: rgba(156, 140, 255, 0.45); }
 .cat-card-inner.rarity-epic { box-shadow: 0 20px 45px rgba(255, 138, 214, 0.35); border-color: rgba(255, 138, 214, 0.45); }
 .cat-card-inner.rarity-legendary { box-shadow: 0 20px 45px rgba(246, 195, 80, 0.35); border-color: rgba(246, 195, 80, 0.45); }
+.cat-card-inner.rarity-deity {
+  border: 4px solid transparent;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.8)) padding-box,
+    var(--deity-border) border-box;
+  box-shadow: 0 20px 50px rgba(255, 182, 230, 0.42);
+}
 
 .cat-portrait {
   position: relative;
@@ -772,6 +800,12 @@ body {
 .rarity-pill.rare { background: var(--rare); }
 .rarity-pill.epic { background: var(--epic); }
 .rarity-pill.legendary { background: linear-gradient(135deg, #f1ba36, #ffd972); color: #5f3d00; }
+.rarity-pill.deity {
+  color: #371b63;
+  border: 2px solid transparent;
+  background: linear-gradient(0deg, rgba(255, 255, 255, 0.96), rgba(255, 255, 255, 0.9)) padding-box,
+    var(--deity-border) border-box;
+}
 
 .close-result {
   margin-top: 1.5rem;


### PR DESCRIPTION
## Summary
- adjust the common rarity weight and register a new deity tier in the odds table
- add the Aurora Muse deity cat and ensure game logic recognizes the new rarity order
- refresh UI legend and rarity visuals with rainbow-bordered deity styling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3fec02560832f8e80b27a278d52a1